### PR TITLE
chore: migrate legacy image URLs to decoims.com

### DIFF
--- a/.deco/blocks/Banner%20Special%20Ballenas%20.json
+++ b/.deco/blocks/Banner%20Special%20Ballenas%20.json
@@ -1,6 +1,6 @@
 {
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "description": "<p><strong><span style=\"color: rgb(222, 227, 229); font-size: 32pt\">Temporada de Ballenas Yubartas</span><br></strong></p><p><strong><span style=\"color: rgb(255, 255, 255); font-size: 16pt\">Julio, Agosto e Septiembre</span></strong></p><p></p><p><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">Haz clic </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 13pt\">aquí</span></strong></a><strong><span style=\"color: rgb(255, 255, 255); font-size: 13pt\"> y consulta las condiciones directamente con nuestro centro de reservas.</span></strong></p>",
-  "src": "https://assets.decocache.com/corumbau/70335d23-d111-49dc-978d-077f06af894b/promo-baleias.jpg",
+  "src": "https://decoims.com/corumbau/1e8a0a3b-adbd-4b2c-afab-ff2bad5739e4/promo-baleias.jpg",
   "alt": "desconto1"
 }

--- a/.deco/blocks/Banner%20Special%20Last%20Holiday%20of%20the%20Year.json
+++ b/.deco/blocks/Banner%20Special%20Last%20Holiday%20of%20the%20Year.json
@@ -2,5 +2,5 @@
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "alt": "desconto1",
   "description": "<p><strong><span style=\"color: rgb(255, 255, 255); font-size: 36pt\">Last holiday of the year!</span></strong></p><p></p><p><span style=\"color: rgb(255, 255, 255); font-size: 16pt\">Enjoy the last holiday of the year and take a dip in this stunning pool!</span></p><p><span style=\"color: rgb(255, 255, 255); font-size: 16pt\">Join us from November 20 to 23 for pure relaxation.</span></p><p></p><p><span style=\"color: rgb(255, 255, 255); font-size: 13pt\">For more information, </span><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 13pt\">click here</span></strong></a><strong><span style=\"color: rgb(170, 208, 16); font-size: 13pt\">, </span><span style=\"color: #ffffff; font-size: 13pt\">or use the booking button above.</span></strong></p><p></p>",
-  "src": "https://data.decoassets.com/corumbau/a9485dcd-c56b-463b-b12c-c6879ac3934c/Light-hotel-foto-2-corte.jpg"
+  "src": "https://decoims.com/corumbau/1dcaebd1-60d9-4709-b338-2d41dd3bd5ea/Light-hotel-foto-2-corte.jpg"
 }

--- a/.deco/blocks/Banner%20Special%20Whale.json
+++ b/.deco/blocks/Banner%20Special%20Whale.json
@@ -2,5 +2,5 @@
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "alt": "desconto1",
   "description": "<p><strong><span style=\"color: #ffffff; font-size: 36pt\">Humpback Whale Season</span></strong></p><p><strong><span style=\"color: #ffffff; font-size: 18pt\">July, August, and September</span></strong></p><p><span style=\"color: #ffffff; font-size: 13pt\">Click</span><span style=\"font-size: 13pt\"> </span><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: #a9c30c; font-size: 13pt\">here</span></strong><span style=\"color: #a9c30c; font-size: 13pt\"> </span></a><span style=\"color: #ffffff; font-size: 13pt\">to check conditions directly with our reservations team.</span></p>",
-  "src": "https://assets.decocache.com/corumbau/70335d23-d111-49dc-978d-077f06af894b/promo-baleias.jpg"
+  "src": "https://decoims.com/corumbau/1e8a0a3b-adbd-4b2c-afab-ff2bad5739e4/promo-baleias.jpg"
 }

--- a/.deco/blocks/Banner%20Special%20offer%201.json
+++ b/.deco/blocks/Banner%20Special%20offer%201.json
@@ -1,6 +1,6 @@
 {
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "description": "<p><span style=\"color: rgb(222, 227, 229); font-size: 32pt\">Dia do Trabalho </span><span style=\"color: rgb(222, 227, 229); font-size: 15pt\">01 a 04 de maio</span></p><p><span style=\"color: rgb(222, 227, 229); font-size: 18pt\">Mínimo 3 noites</span><br><br><span style=\"color: rgb(255, 255, 255); font-size: 16pt\">Venha descansar conosco e ganhe uma massagem relaxante para o casal.</span></p><p></p><p><strong><span style=\"color: rgb(255, 255, 255); font-size: 15pt\">Veja condições diretamente com a nossa central de reservas. </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 15pt\">Clique aqui</span></strong></a><strong><span style=\"color: rgb(255, 255, 255); font-size: 15pt\">.</span></strong></p>",
-  "src": "https://assets.decocache.com/corumbau/89ce1e80-3c44-48f2-bb13-468fef03746a/spa-promo-dia-do-trabalho.jpg",
+  "src": "https://decoims.com/corumbau/4ac9915e-1485-4a83-ad4a-4426598d808d/spa-promo-dia-do-trabalho.jpg",
   "alt": "desconto2"
 }

--- a/.deco/blocks/Banner%20Special%20offer%202.json
+++ b/.deco/blocks/Banner%20Special%20offer%202.json
@@ -1,6 +1,6 @@
 {
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "description": "<p><strong><span style=\"color: #ffffff; font-size: 28pt\">January '26 — Summer Holidays</span><span style=\"color: rgb(255, 255, 255)\"><br></span></strong></p><p><strong><span style=\"color: #ffffff; font-size: 16pt\">Let the summer carry you to Corumbau: a place where the soul finds peace, the sea stays warm, and every detail is cared for with authenticity.</span></strong></p><p></p><p><strong><span style=\"color: #ffffff; font-size: 14pt\">Check availability, rates, and simulate your stay</span><span style=\"color: rgb(255, 255, 255); font-size: 14pt\"> </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://book.omnibees.com/hotel/20763?lang=pt-BR&amp;currencyId=16\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 14pt\">here</span></strong></a><strong><span style=\"color: rgb(255, 255, 255); font-size: 14pt\">.</span></strong></p>",
-  "src": "https://assets.decocache.com/corumbau/f66040e0-fc5b-4288-a3bc-e00f93a00b74/promo-corpus-christi.jpg",
+  "src": "https://decoims.com/corumbau/47a16abf-747a-42dd-b137-dcada0057c76/promo-corpus-christi.jpg",
   "alt": "desconto1"
 }

--- a/.deco/blocks/Banner%20Special%20offer%203.json
+++ b/.deco/blocks/Banner%20Special%20offer%203.json
@@ -1,6 +1,6 @@
 {
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "description": "<p><strong><span style=\"color: rgb(222, 227, 229); font-size: 32pt\">Temporada das Baleias Jubarte </span><br></strong></p><p><strong><span style=\"color: #ffffff; font-size: 16pt\">Julho, Agosto e Setembro</span></strong></p><p></p><p><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">Clique </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 13pt\">aqui</span></strong></a><strong><span style=\"color: rgb(255, 255, 255); font-size: 13pt\"> e veja condições diretamente com a nossa central de reservas.</span></strong></p>",
-  "src": "https://assets.decocache.com/corumbau/70335d23-d111-49dc-978d-077f06af894b/promo-baleias.jpg",
+  "src": "https://decoims.com/corumbau/1e8a0a3b-adbd-4b2c-afab-ff2bad5739e4/promo-baleias.jpg",
   "alt": "desconto1"
 }

--- a/.deco/blocks/Banner%20Special%20offer%204.json
+++ b/.deco/blocks/Banner%20Special%20offer%204.json
@@ -1,6 +1,6 @@
 {
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "description": "<p><strong><span style=\"color: rgb(222, 227, 229); font-size: 32pt\">Carnaval, Paz e Sossego!</span><br><br></strong><span style=\"color: rgb(222, 227, 229); font-size: 18pt\">Venha para Corumbau curtir um Carnaval de sossego e tranquilidade</span><strong><span style=\"color: rgb(222, 227, 229); font-size: 18pt\">. De 13 a 18 de fevereiro de 2026, mínimo de 4  noites.</span></strong></p><p></p><p><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">Para mais informações entre em contato com a nossa central de reservas, </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 13pt\">clique aqui</span></strong></a><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">.</span></strong></p>",
-  "src": "https://data.decoassets.com/corumbau/a9485dcd-c56b-463b-b12c-c6879ac3934c/Light-hotel-foto-2-corte.jpg",
+  "src": "https://decoims.com/corumbau/1dcaebd1-60d9-4709-b338-2d41dd3bd5ea/Light-hotel-foto-2-corte.jpg",
   "alt": "Carnaval"
 }

--- a/.deco/blocks/Carnaval%20ES.json
+++ b/.deco/blocks/Carnaval%20ES.json
@@ -1,6 +1,6 @@
 {
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "description": "<p><span style=\"color: #ffffff; font-size: 32pt\">¡Carnaval, Paz y Tranquilidad!</span><strong><span style=\"color: #ffffff\"><br><br></span></strong><span style=\"color: #ffffff; font-size: 18pt\">Venga a Corumbau y disfrute un Carnaval de descanso y serenidad.</span><strong><span style=\"color: #ffffff; font-size: 18pt\"> Del 13 al 18 de febrero de 2026, con estancia mínima de 4 noches.</span></strong></p><p></p><p><span style=\"color: #ffffff; font-size: 13pt\">Para más información, póngase en contacto con nuestra central de reservas.</span><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\"> </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 13pt\">Haga clic aquí</span></strong></a><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">.</span></strong></p>",
-  "src": "https://data.decoassets.com/corumbau/a9485dcd-c56b-463b-b12c-c6879ac3934c/Light-hotel-foto-2-corte.jpg",
+  "src": "https://decoims.com/corumbau/1dcaebd1-60d9-4709-b338-2d41dd3bd5ea/Light-hotel-foto-2-corte.jpg",
   "alt": "Carnaval"
 }

--- a/.deco/blocks/Carnaval%20PT.json
+++ b/.deco/blocks/Carnaval%20PT.json
@@ -1,6 +1,6 @@
 {
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "description": "<p><strong><span style=\"color: rgb(222, 227, 229); font-size: 32pt\">Carnaval, Paz e Sossego!</span><br><br></strong><span style=\"color: rgb(222, 227, 229); font-size: 18pt\">Venha para Corumbau curtir um Carnaval de sossego e tranquilidade</span><strong><span style=\"color: rgb(222, 227, 229); font-size: 18pt\">. De 13 a 18 de fevereiro de 2026, mínimo de 4  noites.</span></strong></p><p></p><p><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">Para mais informações entre em contato com a nossa central de reservas, </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 13pt\">clique aqui</span></strong></a><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">.</span></strong></p>",
-  "src": "https://data.decoassets.com/corumbau/a9485dcd-c56b-463b-b12c-c6879ac3934c/Light-hotel-foto-2-corte.jpg",
+  "src": "https://decoims.com/corumbau/1dcaebd1-60d9-4709-b338-2d41dd3bd5ea/Light-hotel-foto-2-corte.jpg",
   "alt": "Carnaval"
 }

--- a/.deco/blocks/ESP%20Vacaciones%20Enero.json
+++ b/.deco/blocks/ESP%20Vacaciones%20Enero.json
@@ -1,6 +1,6 @@
 {
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "description": "<p><strong><span style=\"color: #ffffff; font-size: 26pt\">Enero 2026 — Vacaciones de Verano</span><span style=\"color: rgb(255, 255, 255)\"><br></span></strong></p><p><strong><span style=\"color: #ffffff; font-size: 16pt\">Déjate llevar por el verano en Corumbau: un lugar donde el alma encuentra paz, el mar se mantiene cálido y cada detalle es cuidado con autenticidad.</span></strong></p><p></p><p><strong><span style=\"color: #ffffff; font-size: 14pt\">Simula tu estadía y consulta disponibilidades y condiciones</span><span style=\"color: rgb(255, 255, 255); font-size: 14pt\"> </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://book.omnibees.com/hotel/20763?lang=pt-BR&amp;currencyId=16\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 14pt\">aquí</span></strong></a><strong><span style=\"color: rgb(255, 255, 255); font-size: 14pt\">.</span></strong></p>",
-  "src": "https://assets.decocache.com/corumbau/f66040e0-fc5b-4288-a3bc-e00f93a00b74/promo-corpus-christi.jpg",
+  "src": "https://decoims.com/corumbau/47a16abf-747a-42dd-b137-dcada0057c76/promo-corpus-christi.jpg",
   "alt": "desconto1"
 }

--- a/.deco/blocks/offer%203.json
+++ b/.deco/blocks/offer%203.json
@@ -1,6 +1,6 @@
 {
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "description": "<p><strong><span style=\"color: rgb(222, 227, 229); font-size: 32pt\">Temporada das Baleias Jubarte </span><br></strong></p><p><strong><span style=\"color: #ffffff; font-size: 16pt\">Julho, Agosto e Setembro</span></strong></p><p></p><p><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">Clique </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 13pt\">aqui</span></strong></a><strong><span style=\"color: rgb(255, 255, 255); font-size: 13pt\"> e veja condições diretamente com a nossa central de reservas.</span></strong></p>",
-  "src": "https://assets.decocache.com/corumbau/70335d23-d111-49dc-978d-077f06af894b/promo-baleias.jpg",
+  "src": "https://decoims.com/corumbau/1e8a0a3b-adbd-4b2c-afab-ff2bad5739e4/promo-baleias.jpg",
   "alt": "desconto1"
 }

--- a/.deco/blocks/offer%205.json
+++ b/.deco/blocks/offer%205.json
@@ -1,6 +1,6 @@
 {
   "__resolveType": "site/sections/DescriptiveBanner.tsx",
   "description": "<p><strong><span style=\"color: rgb(222, 227, 229); font-size: 32pt\">Ultimo feriado do ano!</span><br><br></strong><span style=\"color: rgb(222, 227, 229); font-size: 18pt\">Aproveite o ultimo feriado do ano e dê um mergulho nesta piscina! De 20 a 23 de novembro venha relaxar conosco!</span></p><p></p><p><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">Para mais informações </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 13pt\">clique aqui</span></strong></a><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\"> ou clique no botaõ de reservas acima!</span></strong></p>",
-  "src": "https://data.decoassets.com/corumbau/a9485dcd-c56b-463b-b12c-c6879ac3934c/Light-hotel-foto-2-corte.jpg",
+  "src": "https://decoims.com/corumbau/1dcaebd1-60d9-4709-b338-2d41dd3bd5ea/Light-hotel-foto-2-corte.jpg",
   "alt": "desconto1"
 }

--- a/.deco/blocks/pages-Especiais-199310.json
+++ b/.deco/blocks/pages-Especiais-199310.json
@@ -88,7 +88,7 @@
             "section": {
               "__resolveType": "site/sections/DescriptiveBanner.tsx",
               "description": "<p><span style=\"color: #ffffff; font-size: 32pt\">Carnival, Peace and Quiet!</span><strong><span style=\"color: #ffffff\"><br><br></span></strong><span style=\"color: #ffffff; font-size: 18pt\">Come to Corumbau and enjoy a Carnival filled with calm and relaxation.</span><strong><span style=\"color: #ffffff; font-size: 18pt\"> From February 13th to 18th, 2026, with a minimum stay of 4 nights.</span></strong></p><p></p><p><span style=\"color: #ffffff; font-size: 13pt\">For more information, please contact our reservations team.</span><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\"> </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 13pt\">Click Here</span></strong></a><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">.</span></strong></p>",
-              "src": "https://data.decoassets.com/corumbau/a9485dcd-c56b-463b-b12c-c6879ac3934c/Light-hotel-foto-2-corte.jpg",
+              "src": "https://decoims.com/corumbau/1dcaebd1-60d9-4709-b338-2d41dd3bd5ea/Light-hotel-foto-2-corte.jpg",
               "alt": "Carnaval"
             }
           },
@@ -139,7 +139,7 @@
             "section": {
               "__resolveType": "site/sections/DescriptiveBanner.tsx",
               "description": "<p><strong><span style=\"color: rgb(255, 255, 255); font-size: 28pt\">Janeiro 2026 — Férias de Verão</span><span style=\"color: rgb(255, 255, 255)\"><br></span></strong></p><p><strong><span style=\"color: #fdfcfc; font-size: 16pt\">Deixe o verão te levar a Corumbau — onde a alma encontra paz, o mar permanece quente e cada detalhe é cuidado com autenticidade. </span></strong></p><p></p><p><span style=\"color: #ffffff; font-size: 14pt\">Simule a sua estadia, veja diponibilidades e condições</span><strong><span style=\"color: rgb(255, 255, 255); font-size: 14pt\"> </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://book.omnibees.com/hotel/20763?lang=pt-BR&amp;currencyId=16\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 14pt\">aqui</span></strong></a><strong><span style=\"color: rgb(255, 255, 255); font-size: 14pt\">.</span></strong></p>",
-              "src": "https://assets.decocache.com/corumbau/f66040e0-fc5b-4288-a3bc-e00f93a00b74/promo-corpus-christi.jpg",
+              "src": "https://decoims.com/corumbau/47a16abf-747a-42dd-b137-dcada0057c76/promo-corpus-christi.jpg",
               "alt": "desconto1"
             }
           },
@@ -148,7 +148,7 @@
             "section": {
               "__resolveType": "site/sections/DescriptiveBanner.tsx",
               "description": "<p><strong><span style=\"color: rgb(222, 227, 229); font-size: 32pt\">Carnaval, Paz e Sossego!</span><br><br></strong><span style=\"color: rgb(222, 227, 229); font-size: 18pt\">Venha para Corumbau curtir um Carnaval de sossego e tranquilidade</span><strong><span style=\"color: rgb(222, 227, 229); font-size: 18pt\">. De 13 a 18 de fevereiro de 2026, mínimo de 4  noites.</span></strong></p><p></p><p><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">Para mais informações entre em contato com a nossa central de reservas, </span></strong><a target=\"_blank\" rel=\"noopener noreferrer nofollow\" href=\"https://wa.me/551130784411\"><strong><span style=\"color: rgb(170, 208, 16); font-size: 13pt\">clique aqui</span></strong></a><strong><span style=\"color: rgb(222, 227, 229); font-size: 13pt\">.</span></strong></p>",
-              "src": "https://data.decoassets.com/corumbau/a9485dcd-c56b-463b-b12c-c6879ac3934c/Light-hotel-foto-2-corte.jpg",
+              "src": "https://decoims.com/corumbau/1dcaebd1-60d9-4709-b338-2d41dd3bd5ea/Light-hotel-foto-2-corte.jpg",
               "alt": "Carnaval"
             }
           },

--- a/.deco/blocks/pages-Sobre-874094.json
+++ b/.deco/blocks/pages-Sobre-874094.json
@@ -270,51 +270,51 @@
               "__resolveType": "site/sections/Carousel.tsx",
               "slides": [
                 {
-                  "src": "https://data.decoassets.com/corumbau/a77bfe25-30f6-4d7b-a742-498088141784/Light-hotel-1.jpg",
+                  "src": "https://decoims.com/corumbau/1ed5adb3-d88f-4b92-8953-e0bb9ce315ef/Light-hotel-1.jpg",
                   "alt": "slider1"
                 },
                 {
-                  "src": "https://data.decoassets.com/corumbau/a9485dcd-c56b-463b-b12c-c6879ac3934c/Light-hotel-foto-2-corte.jpg",
+                  "src": "https://decoims.com/corumbau/1dcaebd1-60d9-4709-b338-2d41dd3bd5ea/Light-hotel-foto-2-corte.jpg",
                   "alt": "slider2"
                 },
                 {
-                  "src": "https://data.decoassets.com/corumbau/0bbc6b41-14aa-4335-83cd-e3fbb87bb257/Light-Site-hotel-3-corte.jpg",
+                  "src": "https://decoims.com/corumbau/495bcccc-a237-407f-b2c8-396220f2ab92/Light-Site-hotel-3-corte.jpg",
                   "alt": "slider3"
                 },
                 {
-                  "src": "https://data.decoassets.com/corumbau/f82a9c90-b96b-4f39-83d3-998ed672adc6/light-Site-hotel-4-corte.jpg",
+                  "src": "https://decoims.com/corumbau/ed1ed9b3-e730-40b7-9ae4-a08e3a4f195a/light-Site-hotel-4-corte.jpg",
                   "alt": "slider4"
                 },
                 {
-                  "src": "https://data.decoassets.com/corumbau/2159e994-7a8b-4524-9b7f-8b3b45135a5d/light-Site-hotel-5-corte.jpg",
+                  "src": "https://decoims.com/corumbau/e9fc54e4-5d96-4b3d-b360-212dde04ded3/light-Site-hotel-5-corte.jpg",
                   "alt": "slider5"
                 },
                 {
-                  "src": "https://data.decoassets.com/corumbau/e2ca11c7-69e1-4149-b6b5-0358bd5ae091/light-Site-hotel-6-corte.jpg",
+                  "src": "https://decoims.com/corumbau/4f46613c-2a98-4033-a848-4d6073ecd617/light-Site-hotel-6-corte.jpg",
                   "alt": "slider6"
                 },
                 {
-                  "src": "https://data.decoassets.com/corumbau/3fd0eac3-be0c-42fc-af6d-49b2856a78fc/light-Site-hotel-8-corte.jpg",
+                  "src": "https://decoims.com/corumbau/a36482db-e32a-4695-97b6-215db467f677/light-Site-hotel-8-corte.jpg",
                   "alt": "slider7"
                 },
                 {
-                  "src": "https://data.decoassets.com/corumbau/a3930085-3f19-4734-94c5-ec1735c742f2/light-Site-hotel-7-corte.JPG",
+                  "src": "https://decoims.com/corumbau/555d6206-f7a6-4aa4-a5c4-b6b5abefa4ef/light-Site-hotel-7-corte.JPG",
                   "alt": "slider8"
                 },
                 {
                   "alt": "slider9",
-                  "src": "https://data.decoassets.com/corumbau/0a96dc95-58af-4ac3-89ed-dedd4b75c24d/light-Site-hotel-9-corte.jpg"
+                  "src": "https://decoims.com/corumbau/3d002f93-7072-4181-b240-779c0ea30a82/light-Site-hotel-9-corte.jpg"
                 },
                 {
-                  "src": "https://data.decoassets.com/corumbau/918997bb-7f42-42b5-bf60-49bdbd872454/light-Site-hotel-10-corte.jpg",
+                  "src": "https://decoims.com/corumbau/b9c8e2a6-923c-4776-8901-8c112edae671/light-Site-hotel-10-corte.jpg",
                   "alt": "slider10"
                 },
                 {
-                  "src": "https://data.decoassets.com/corumbau/005d7916-4bc4-43c0-bd94-68dd2ea2a0c6/light-Site-hotel-11-corte.jpg",
+                  "src": "https://decoims.com/corumbau/cc1629b7-eee5-4b60-8a77-052163fa2dcc/light-Site-hotel-11-corte.jpg",
                   "alt": "slider11"
                 },
                 {
-                  "src": "https://data.decoassets.com/corumbau/4ebe8dce-74a3-46b4-acab-7e577f4e936d/light-Site-hotel-12-corte.jpg",
+                  "src": "https://decoims.com/corumbau/7c928b26-093d-449e-96fa-05fee746ba71/light-Site-hotel-12-corte.jpg",
                   "alt": "slider12"
                 }
               ]
@@ -325,7 +325,7 @@
             "section": {
               "__resolveType": "site/sections/ImageWithParagraph.tsx",
               "description": "A Fazenda São Francisco do Corumbau conta com 167 hectares de área e reúne as comodidades de um hotel de luxo com o charme e o despojamento de uma casa de praia.\n\nO projeto do arquiteto Roberto Migotto combina recursos da infraestrutura moderna com a amplitude do espaço e a exuberância da natureza local.",
-              "image": "https://data.decoassets.com/corumbau/2a204a20-9d06-45a3-8b48-43ae3940145c/Site-Hotel-(Espreguicadeira-e-Carla)-light.JPG",
+              "image": "https://decoims.com/corumbau/2580f150-ce4c-4c39-aaf2-b0190112a091/Site-Hotel-(Espreguicadeira-e-Carla)-light.JPG",
               "placement": "left",
               "paragraph": [
                 null

--- a/.deco/blocks/site.json
+++ b/.deco/blocks/site.json
@@ -4,10 +4,10 @@
     "jsonLDs": [],
     "noIndexing": false,
     "descriptionTemplate": "%s | www.corumbau.com.br",
-    "image": "https://ozksgdmyrqcxcwhnbepg.supabase.co/storage/v1/object/public/assets/12097/b62cf9db-6294-456a-99fc-4cbe643c9723",
+    "image": "https://decoims.com/corumbau/68e57788-5893-49a6-a2fa-40ac2831820f/b62cf9db-6294-456a-99fc-4cbe643c9723.jpg",
     "title": "Fazenda São Francisco do Corumbau",
     "titleTemplate": "%s",
-    "favicon": "https://deco-sites-assets.s3.sa-east-1.amazonaws.com/corumbau/206981f9-99a1-4d9a-bb3b-2ccbf6ed10d0/AF-Logo-Amendoeira-560.png"
+    "favicon": "https://decoims.com/corumbau/22a63de7-4ecd-4c2e-851e-ff04c1e3e9ce/AF-Logo-Amendoeira-560.png"
   },
   "global": [
     {


### PR DESCRIPTION
Migração automática de URLs de imagens legadas para decoims.com.

- Substituição de domínios legados (`assets.decocache.com` etc.) por `decoims.com`
- Apenas substituição de strings nos arquivos de configuração/blocos

**Não fazer merge sem revisão.**